### PR TITLE
getSourcesRoot checks "this.dtsOut" to set itself

### DIFF
--- a/src/org/jsweet/AbstractJSweetMojo.java
+++ b/src/org/jsweet/AbstractJSweetMojo.java
@@ -243,7 +243,7 @@ public abstract class AbstractJSweetMojo extends AbstractMojo {
 
 	protected File getSourceRoot() throws IOException {
 		File sourceRoot = null;
-		if (isNotBlank(this.dtsOut)) {
+		if (isNotBlank(this.sourceRoot)) {
 			sourceRoot = new File(this.sourceRoot);
 		}
 		return sourceRoot;


### PR DESCRIPTION
Which doesn't work if we use dtsOut but not sourcesRoot as a configuration option.

Probably just an unlucky copy-paste :)