### PR TITLE
Support to use shared source files from resources 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@
 		</dependency>
 		<!-- Compile-time only dependency (JSweet looks up installed JDK at runtime 
 			to conform to legal obligations) -->
+		<!-- Comment following dependency, when running on mac -->
 		<dependency>
 			<groupId>com.sun</groupId>
 			<artifactId>tools</artifactId>


### PR DESCRIPTION
Support for using shared java code on project by including external java source code as resources. 

The idea is copied from GWT modules, where the source code is included on maven package and reused on compile time.