### PR TITLE
Enable Usage of Custom Factory Classes in Plugin

### DIFF
--- a/.settings/.gitignore
+++ b/.settings/.gitignore
@@ -1,0 +1,2 @@
+/org.eclipse.jdt.ui.prefs
+/org.eclipse.jdt.core.prefs

--- a/pom.xml
+++ b/pom.xml
@@ -105,19 +105,13 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
-			<version>3.3.3</version>
+			<version>3.5.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-core</artifactId>
-			<version>3.3.3</version>
+			<version>3.5.3</version>
 
-			<exclusions>
-				<exclusion>
-					<groupId>com.google.guava</groupId>
-					<artifactId>guava</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
@@ -128,12 +122,6 @@
 			<groupId>org.jsweet</groupId>
 			<artifactId>jsweet-transpiler</artifactId>
 			<version>2.2.0-SNAPSHOT</version>
-			<exclusions>
-				<exclusion>
-					<groupId>com.google.guava</groupId>
-					<artifactId>guava</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jsweet</groupId>
 	<artifactId>jsweet-maven-plugin</artifactId>
-	<version>2.2.0-SNAPSHOT</version>
+	<version>2.2.1-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 	<description>JSweet maven plugin providing build and clean operations of JSweet sources</description>
 
@@ -109,8 +109,15 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-project</artifactId>
-			<version>2.2.1</version>
+			<artifactId>maven-core</artifactId>
+			<version>3.3.3</version>
+
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
@@ -121,6 +128,12 @@
 			<groupId>org.jsweet</groupId>
 			<artifactId>jsweet-transpiler</artifactId>
 			<version>2.2.0-SNAPSHOT</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>

--- a/src/main/java/org/jsweet/JSweetMojo.java
+++ b/src/main/java/org/jsweet/JSweetMojo.java
@@ -36,7 +36,7 @@ public class JSweetMojo extends AbstractJSweetMojo {
 
 		MavenProject project = getMavenProject();
 
-		JSweetTranspiler transpiler = createJSweetTranspiler();
+		JSweetTranspiler transpiler = createJSweetTranspiler(project);
 
 		transpile(project, transpiler);
 	}

--- a/src/main/java/org/jsweet/JSweetWatchMojo.java
+++ b/src/main/java/org/jsweet/JSweetWatchMojo.java
@@ -61,7 +61,7 @@ public class JSweetWatchMojo extends AbstractJSweetMojo {
 
 		MavenProject project = getMavenProject();
 
-		transpiler = createJSweetTranspiler();
+		transpiler = createJSweetTranspiler(project);
 
 		getLog().info("- Starting transpilator process  ... ");
 


### PR DESCRIPTION
These changes enable custom Jsweet factory classes to be used in a project without having to spilt those classes out into a separate jar. The plugin dependencies also had to be updated to support the new code. 

fixes issue #40 