### PR TITLE
Allow dependencies with scopes other than "compile" on the transpiler classpath

### DIFF
--- a/src/main/java/org/jsweet/JSweetWatchMojo.java
+++ b/src/main/java/org/jsweet/JSweetWatchMojo.java
@@ -289,7 +289,7 @@ public class JSweetWatchMojo extends AbstractJSweetMojo {
 					}
 					__Lock.unlock();
 				}
-				yield();
+				Thread.yield();
 			}
 		}
 	}


### PR DESCRIPTION
`Added a config param to allow non-compile scoped dependencies on the classpath for the jsweet mojos`

My use-case is that I have a standalone library that is built and deployed as both Java and JavaScript.  JSweet is used for transpilation, with standard JS tools in the build pipeline to produce a JS library to be deployed to npmjs.  However, the Java library itself is also built and published to maven central.  I don't want the JSweet dependencies as transitive deps on my Java library, since they are only needed for transpilation.  However, I have a JSweet extension, which fails to compile without the JSweet dependencies.  Currently the **only** way to get the JSweet dependencies on the transpiler classpath is to have them as `compile` dependencies of the project.

This PR adds a new Mojo parameter that allows overriding that default - the config now allows whatever scopes you want to be included.

It also improves the logging output to indicate why a dependency is excluded and fixes a compile problem on some JVMs with the non static usage of `Thread.yield`.