### PR TITLE
Fix compilation with Java 13 or newer, handle "yield"

### DIFF
--- a/src/main/java/org/jsweet/JSweetWatchMojo.java
+++ b/src/main/java/org/jsweet/JSweetWatchMojo.java
@@ -289,7 +289,7 @@ public class JSweetWatchMojo extends AbstractJSweetMojo {
 					}
 					__Lock.unlock();
 				}
-				yield();
+				Thread.yield();
 			}
 		}
 	}


### PR DESCRIPTION
"yield" is a new keyword since Java 13 (in certain situations only). Calling yield() is no longer supported.

Rename to Thread.yield() to permit building again.